### PR TITLE
Use the table schema name if one was defined.

### DIFF
--- a/src/OracleProvider/Query/Sql/Internal/OracleQuerySqlGenerator.cs
+++ b/src/OracleProvider/Query/Sql/Internal/OracleQuerySqlGenerator.cs
@@ -305,7 +305,7 @@ namespace Microsoft.EntityFrameworkCore.Oracle.Query.Sql.Internal
         {
             Check.NotNull(tableExpression, nameof(tableExpression));
 
-            Sql.Append(SqlGenerator.DelimitIdentifier(tableExpression.Table))
+            Sql.Append(SqlGenerator.DelimitIdentifier(tableExpression.Table, tableExpression.Schema))
                 .Append(" ")
                 .Append(SqlGenerator.DelimitIdentifier(tableExpression.Alias));
 

--- a/src/OracleProvider/Storage/Internal/OracleSqlGenerationHelper.cs
+++ b/src/OracleProvider/Storage/Internal/OracleSqlGenerationHelper.cs
@@ -38,9 +38,6 @@ namespace Microsoft.EntityFrameworkCore.Oracle.Storage.Internal
         public override string DelimitIdentifier(string identifier)
             => $"\"{EscapeIdentifier(Check.NotEmpty(identifier, nameof(identifier)))}\""; // Interpolation okay; strings
 
-        public override string DelimitIdentifier(string name, string schema)
-            => DelimitIdentifier(name);
-
         public override void DelimitIdentifier(StringBuilder builder, string identifier)
         {
             Check.NotEmpty(identifier, nameof(identifier));
@@ -49,8 +46,5 @@ namespace Microsoft.EntityFrameworkCore.Oracle.Storage.Internal
             EscapeIdentifier(builder, identifier);
             builder.Append('"');
         }
-
-        public override void DelimitIdentifier(StringBuilder builder, string name, string schema)
-            => DelimitIdentifier(builder, name);
     }
 }


### PR DESCRIPTION
Right now if you add a define a different schema via say the table attribute

    [Table("Blog", Schema = "Banana")] 

it won't generate the proper "Banana"."Blog" reference in the sql. Just "Blog".

Simply need to make it pass the schema to the DelimitIdentifierfunction and remove the two custom definitions for DelimitIdentifier because the base function in RelationalSqlGenerationHelper already does the correct format.