### PR TITLE
Update RelationalMaxIdentifierLengthConvention

### DIFF
--- a/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
+++ b/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             var valueGenerationStrategyConvention = new OracleValueGenerationStrategyConvention();
             conventionSet.ModelInitializedConventions.Add(valueGenerationStrategyConvention);
-            conventionSet.ModelInitializedConventions.Add(new RelationalMaxIdentifierLengthConvention(128));
+            conventionSet.ModelInitializedConventions.Add(new RelationalMaxIdentifierLengthConvention(30));
 
             ValueGeneratorConvention valueGeneratorConvention = new OracleValueGeneratorConvention();
             ReplaceConvention(conventionSet.BaseEntityTypeChangedConventions, valueGeneratorConvention);


### PR DESCRIPTION
Oracle uses 30 characters as the maximum identifier lenght.

Even changing the error continues.
ORA-00972: identifier is too long