### PR TITLE
Adjust OracleQueryCompilationContext

### DIFF
--- a/src/OracleProvider/Query/Internal/OracleQueryCompilationContext.cs
+++ b/src/OracleProvider/Query/Internal/OracleQueryCompilationContext.cs
@@ -4,11 +4,16 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using System;
+using System.Collections.Generic;
 
 namespace Microsoft.EntityFrameworkCore.Oracle.Query.Internal
 {
     public class OracleQueryCompilationContext : RelationalQueryCompilationContext
     {
+        private readonly ISet<string> _tableAliasSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         public OracleQueryCompilationContext(
             [NotNull] QueryCompilationContextDependencies dependencies,
             [NotNull] ILinqOperatorProvider linqOperatorProvider,
@@ -23,5 +28,42 @@ namespace Microsoft.EntityFrameworkCore.Oracle.Query.Internal
         }
 
         public override bool IsLateralJoinSupported => true;
+
+        public override int MaxTableAliasLength => 5;
+
+        private string GetRandomLetter(Random rng)
+        {
+            var letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+            int index = rng.Next(letters.Length);
+            return letters[index].ToString();
+        }
+
+        private string GetUniqueTableAlias()
+        {
+            var rdm = new Random();
+
+            return GetRandomLetter(rdm) + rdm.Next(0, 10);
+        }
+
+        public override string CreateUniqueTableAlias([NotNull] string currentAlias)
+        {
+            Check.NotNull(currentAlias, nameof(currentAlias));
+
+            if (currentAlias.Length == 0)
+            {
+                return currentAlias;
+            }
+
+            var uniqueAlias = GetUniqueTableAlias();
+
+            while (_tableAliasSet.Contains(uniqueAlias))
+            {
+                uniqueAlias = GetUniqueTableAlias();
+            }
+
+            _tableAliasSet.Add(uniqueAlias);
+
+            return uniqueAlias;
+        }
     }
 }


### PR DESCRIPTION
Generates a random alias with a letter and a number between 0 to 9 to avoid the error below.

ORA-00972: identifier is too long.